### PR TITLE
Add Honkit and DocBase integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:14
+
+# Create app directory
+WORKDIR /app
+
+# Copy project files
+COPY . .
+
+# Install app dependencies
+RUN npm install
+
+# Serve the Honkit project
+CMD ["npx", "honkit", "serve"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+import-docbase:
+	npx ts-node scripts/import-docbase.ts
+
+serve:
+	npx honkit serve

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # honkit-investigation
+
+## Instructions
+
+### Install Dependencies
+To install the necessary dependencies, run:
+```
+npm install
+```
+
+### Import DocBase Articles
+To import articles from DocBase, run the following script:
+```
+npx ts-node scripts/import-docbase.ts
+```
+
+### Build and Serve Honkit Project
+To build and serve the Honkit project, run:
+```
+npx honkit serve
+```
+
+### Supported Languages
+The Honkit viewer supports multiple languages.

--- a/book.json
+++ b/book.json
@@ -1,0 +1,5 @@
+{
+  "title": "DocBase Viewer",
+  "author": "Your Name",
+  "plugins": ["honkit-plugin"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+
+services:
+  honkit-viewer:
+    build:
+      context: .
+    ports:
+      - "4000:4000"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "honkit-investigation",
+  "version": "1.0.0",
+  "description": "A project to use Honkit to automatically import DocBase articles and operate as a viewer",
+  "main": "index.js",
+  "scripts": {
+    "import-docbase": "ts-node scripts/import-docbase.ts",
+    "serve": "honkit serve"
+  },
+  "author": "Your Name",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1",
+    "honkit": "^3.6.9"
+  },
+  "devDependencies": {
+    "ts-node": "^10.0.0",
+    "typescript": "^4.3.5"
+  }
+}

--- a/scripts/import-docbase.ts
+++ b/scripts/import-docbase.ts
@@ -1,0 +1,48 @@
+import axios from 'axios';
+import fs from 'fs';
+import path from 'path';
+
+const DOCBASE_API_URL = 'https://api.docbase.io';
+const DOCBASE_TEAM = 'your_team';
+const DOCBASE_TOKEN = 'your_token';
+
+async function fetchDocBaseArticles() {
+  try {
+    const response = await axios.get(`${DOCBASE_API_URL}/teams/${DOCBASE_TEAM}/posts`, {
+      headers: {
+        'X-DocBaseToken': DOCBASE_TOKEN,
+      },
+    });
+
+    const articles = response.data.posts;
+    return articles;
+  } catch (error) {
+    console.error('Error fetching articles from DocBase:', error);
+    throw error;
+  }
+}
+
+function saveArticlesAsMarkdown(articles: any[]) {
+  const docsDir = path.join(__dirname, '../docs');
+
+  if (!fs.existsSync(docsDir)) {
+    fs.mkdirSync(docsDir);
+  }
+
+  articles.forEach((article) => {
+    const filePath = path.join(docsDir, `${article.id}.md`);
+    fs.writeFileSync(filePath, article.body);
+  });
+}
+
+async function importDocBaseArticles() {
+  try {
+    const articles = await fetchDocBaseArticles();
+    saveArticlesAsMarkdown(articles);
+    console.log('Successfully imported DocBase articles.');
+  } catch (error) {
+    console.error('Failed to import DocBase articles.');
+  }
+}
+
+importDocBaseArticles();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["scripts/**/*.ts"]
+}


### PR DESCRIPTION
Add functionality to use Honkit to automatically import DocBase articles and operate as a viewer.

* **Add Honkit Configuration**: Add `book.json` to configure Honkit with title, author, and plugins.
* **Add Import Script**: Add `scripts/import-docbase.ts` to fetch articles from DocBase API and save them as markdown files in the `docs` directory.
* **Update README**: Add instructions to install dependencies, import DocBase articles, and build and serve the Honkit project.
* **Add Package Configuration**: Add `package.json` with project metadata, scripts, dependencies, and devDependencies.
* **Add TypeScript Configuration**: Add `tsconfig.json` with compiler options and include paths.
* **Add Makefile**: Add targets to run the import script and serve the Honkit project.
* **Add Docker Configuration**: Add `Dockerfile` to create a Docker image for the Honkit project and `docker-compose.yml` to define the service and map ports.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/susumutomita/honkit-investigation?shareId=43c2001a-9ad6-4543-b42e-2931b65ad96a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a Docker configuration for easier deployment of the Honkit application.
  - Added functionality to import articles from DocBase and serve them as Markdown files.
  - New metadata file (`book.json`) created for project configuration.

- **Documentation**
  - Updated `README.md` with installation and usage instructions, including dependency installation and project serving.

- **Chores**
  - New configuration files (`package.json`, `tsconfig.json`, `docker-compose.yml`) added to support project structure and build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->