### PR TITLE
add pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy Honkit to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  # デフォルトブランチ名を指定
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'  # 使用するNode.jsのバージョン
+
+    - name: Install dependencies
+      run: make install
+
+    - name: Build Honkit
+      run: make build
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./_book
+        publish_branch: gh-pages


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to automate the deployment of Honkit to GitHub Pages. The workflow triggers on pushes to the `main` branch and can also be manually triggered. The most important changes include defining the workflow configuration, setting up the environment, and specifying the deployment steps.

### Workflow configuration:
* [`.github/workflows/pages.yml`](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5R1-R33): Added a new workflow named "Deploy Honkit to GitHub Pages" that triggers on pushes to the `main` branch and on manual dispatch.

### Environment setup:
* [`.github/workflows/pages.yml`](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5R1-R33): Configured the workflow to run on `ubuntu-latest` and set up Node.js version 20.

### Deployment steps:
* [`.github/workflows/pages.yml`](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5R1-R33): Defined steps to check out the repository, install dependencies, build Honkit, and deploy the build to the `gh-pages` branch using the `peaceiris/actions-gh-pages` action.