### PR TITLE
fix permission error

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,32 +2,47 @@ name: Deploy Honkit to GitHub Pages
 
 on:
   push:
-    branches:
-      - main  # デフォルトブランチ名を指定
+    branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  build:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'  # 使用するNode.jsのバージョン
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
-    - name: Install dependencies
-      run: make install
+      - name: Install dependencies
+        run: make install
 
-    - name: Build Honkit
-      run: make build
+      - name: Build Honkit
+        run: make build
 
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./_book
-        publish_branch: gh-pages
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './_book'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying Honkit to GitHub Pages. The changes include improvements to permissions, concurrency settings, and job configurations.

Workflow improvements:

* [`.github/workflows/pages.yml`](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5L5-R48): Updated permissions to include `contents: read`, `pages: write`, and `id-token: write`.
* [`.github/workflows/pages.yml`](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5L5-R48): Added concurrency settings to manage deployments with a group named "pages" and `cancel-in-progress` set to `false`.

Job configuration changes:

* [`.github/workflows/pages.yml`](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5L5-R48): Changed the job name from `build` to `deploy`, included environment settings for `github-pages`, and updated the URL to use `${{ steps.deployment.outputs.page_url }}`.
* [`.github/workflows/pages.yml`](diffhunk://#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5L5-R48): Replaced the `peaceiris/actions-gh-pages` action with `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages` for a more streamlined deployment process.